### PR TITLE
Dedicated timing plots for L1T objects- Online DQM & L1T

### DIFF
--- a/DQM/HLTEvF/plugins/LumiMonitor.h
+++ b/DQM/HLTEvF/plugins/LumiMonitor.h
@@ -41,7 +41,7 @@ class LumiMonitor : public DQMEDAnalyzer
 {
 public:
   LumiMonitor( const edm::ParameterSet& );
-  ~LumiMonitor() = default;
+  ~LumiMonitor() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   static void fillHistoPSetDescription(edm::ParameterSetDescription & pset);
   static void fillHistoLSPSetDescription(edm::ParameterSetDescription & pset);
@@ -60,6 +60,7 @@ private:
 
   edm::EDGetTokenT<LumiScalersCollection> lumiScalersToken_;
   MEbinning lumi_binning_;
+  MEbinning pu_binning_;
   MEbinning ls_binning_;
 
   bool  doPixelLumi_;
@@ -76,6 +77,7 @@ private:
   MonitorElement* numberOfPixelClustersVsLS_;
   MonitorElement* numberOfPixelClustersVsLumi_;
   MonitorElement* lumiVsLS_;
+  MonitorElement* puVsLS_;
   MonitorElement* pixelLumiVsLS_;
   MonitorElement* pixelLumiVsLumi_;
 

--- a/DQM/HLTEvF/python/LumiMonitor_cff.py
+++ b/DQM/HLTEvF/python/LumiMonitor_cff.py
@@ -19,6 +19,11 @@ lumiMonitor = cms.EDAnalyzer("LumiMonitor",
             xmin  = cms.double( 3000.),
             xmax  = cms.double(12000.),
       ),
+      puPSet                      = cms.PSet(
+            nbins = cms.int32 (260 ),
+            xmin  = cms.double(  0.),
+            xmax  = cms.double(130.),
+      ),
       pixellumiPSet               = cms.PSet(
             nbins = cms.int32 (300 ),
             xmin  = cms.double(  0.),

--- a/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackInnerTrackMuons_cff.py
@@ -44,4 +44,4 @@ MonitorTrackMuonsInnerTrack.doEffFromHitPatternVsPU = True
 MonitorTrackMuonsInnerTrack.doEffFromHitPatternVsBX = False
 
 #MonitorTrackINNMuons = cms.Sequence(muonInnerTrack+MonitorTrackMuonsInnerTrack)
-MonitorTrackINNMuons = cms.Sequence(muonsPt10+muonInnerTrack+MonitorTrackMuonsInnerTrack)
+MonitorTrackINNMuons = cms.Sequence(cms.ignore(muonsPt10)+muonInnerTrack+MonitorTrackMuonsInnerTrack)

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -16,6 +16,7 @@ from DQM.BeamMonitor.AlcaBeamMonitorClient_cff import *
 from DQMServices.Components.DQMFEDIntegrityClient_cff import *
 from Validation.RecoTau.DQMSequences_cfi import *
 from DQMOffline.Hcal.HcalDQMOfflinePostProcessor_cff import *
+from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQM.HcalTasks.OfflineHarvestingSequence_pp import *
 
 DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
@@ -28,7 +29,8 @@ DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                              es_dqm_client_offline *
                                              hcalOfflineHarvesting *
                                              HcalDQMOfflinePostProcessor * 
-                                             dqmFEDIntegrityClient )
+                                             dqmFEDIntegrityClient *
+                                             l1TriggerDqmOfflineClient )
 
 DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
                                          DQMOffline_SecondStep_PreDPG *
@@ -36,7 +38,6 @@ DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
 
 from DQMOffline.Muon.muonQualityTests_cff import *
 from DQMOffline.EGamma.egammaPostProcessing_cff import *
-from DQMOffline.L1Trigger.L1TriggerDqmOffline_cff import *
 from DQMOffline.Trigger.DQMOffline_Trigger_Client_cff import *
 from DQMOffline.Trigger.DQMOffline_HLT_Client_cff import *
 from DQMOffline.RecoB.dqmCollector_cff import *
@@ -86,11 +87,11 @@ DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  PixelOfflineDQMClientNoDataCertification *
                                  triggerOfflineDQMClient *
                                  hltOfflineDQMClient *
+                                 l1TriggerDqmOfflineClient *
                                  dqmFEDIntegrityClient *
                                  alcaBeamMonitorClient *
                                  runTauEff *
-                                 dqmFastTimerServiceClient *
-                                 l1TriggerDqmOfflineClient
+                                 dqmFastTimerServiceClient
                                 )
 DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                DQMMessageLoggerClientSeq *
@@ -100,6 +101,7 @@ DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                PixelOfflineDQMClientNoDataCertification *
                                                triggerOfflineDQMClient *
                                                hltOfflineDQMClient *
+                                               l1TriggerDqmOfflineClient *
                                                dqmFEDIntegrityClient *
                                                alcaBeamMonitorClient *
                                                runTauEff  *

--- a/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
@@ -4,33 +4,42 @@ import FWCore.ParameterSet.Config as cms
 #hltScalersRawToDigi4DQM = cms.EDProducer( "ScalersRawToDigi",
 #    scalersInputTag = cms.InputTag( "rawDataCollector" )
 #)
-hltLumiMonitor = cms.EDAnalyzer( "LumiMonitor",
-    useBPixLayer1 = cms.bool( False ),
-    minPixelClusterCharge = cms.double( 15000.0 ),
-    histoPSet = cms.PSet(
-      lsPSet = cms.PSet(  nbins = cms.int32( 2500 ) ),
-      pixelClusterPSet = cms.PSet(
-        nbins = cms.int32( 200 ),
-        xmin = cms.double( -0.5 ),
-        xmax = cms.double( 19999.5 )
-      ),
-      lumiPSet = cms.PSet(
-        nbins = cms.int32( 5000 ),
-        xmin = cms.double( 0.0 ),
-        xmax = cms.double( 20000.0 )
-      ),
-      pixellumiPSet = cms.PSet(
-        nbins = cms.int32( 300 ),
-        xmin = cms.double( 0.0 ),
-        xmax = cms.double( 3.0 )
-      )
+
+from DQM.HLTEvF.lumiMonitor_cfi import lumiMonitor
+
+hltLumiMonitor = lumiMonitor.clone()
+hltLumiMonitor.useBPixLayer1 = cms.bool( False )
+hltLumiMonitor.minPixelClusterCharge = cms.double( 15000.0 )
+hltLumiMonitor.histoPSet = cms.PSet(
+    lsPSet = cms.PSet(  
+      nbins = cms.int32( 2500 ) 
     ),
-    minNumberOfPixelsPerCluster = cms.int32( 2 ),
-    FolderName = cms.string( "HLT/LumiMonitoring" ),
-    scalers = cms.InputTag( "scalersRawToDigi" ),
-    pixelClusters = cms.InputTag( "hltSiPixelClusters" ),
-    doPixelLumi = cms.bool( False )
+    pixelClusterPSet = cms.PSet(
+      nbins = cms.int32( 200 ),
+      xmin = cms.double( -0.5 ),
+      xmax = cms.double( 19999.5 )
+    ),
+    puPSet = cms.PSet(
+      nbins = cms.int32( 130  ),
+      xmin = cms.double(   0. ),
+      xmax = cms.double( 130. )
+    ),
+    lumiPSet = cms.PSet(
+      nbins = cms.int32(   440 ),
+      xmin = cms.double(     0.0 ),
+      xmax = cms.double( 22000.0 )
+    ),
+    pixellumiPSet = cms.PSet(
+      nbins = cms.int32( 300 ),
+      xmin = cms.double( 0.0 ),
+      xmax = cms.double( 3.0 )
+    )
 )
+hltLumiMonitor.minNumberOfPixelsPerCluster = cms.int32( 2 )
+hltLumiMonitor.FolderName = cms.string( "HLT/LumiMonitoring" )
+hltLumiMonitor.scalers = cms.InputTag( "scalersRawToDigi" )
+hltLumiMonitor.pixelClusters = cms.InputTag( "hltSiPixelClusters" )
+hltLumiMonitor.doPixelLumi = cms.bool( False )
 
 lumiMonitorHLTsequence = cms.Sequence(
 #    hltScalersRawToDigi4DQM +

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -81,14 +81,15 @@ from DQMOffline.Trigger.BTaggingMonitoring_cff import *
 from DQMOffline.Trigger.BPHMonitor_cff import *
 # remove quadJetAna
 from DQMOffline.Trigger.topHLTOfflineDQM_cff import *
-offlineHLTSource = cms.Sequence(
+
+# offline DQM for running also on AOD (w/o the need of the RECO step on-the-fly)
+## ADD here sequences/modules which rely ONLY on collections stored in the AOD format
+offlineHLTSourceOnAOD = cms.Sequence(
     hltResults *
     lumiMonitorHLTsequence *
-    hcalMonitoringSequence *
     egHLTOffDQMSource *
     muonFullOfflineDQM *
     HLTTauDQMOffline *
-    jetMETHLTOfflineAnalyzer * 
     fsqHLTOfflineSourceSequence *
     HILowLumiHLTOfflineSourceSequence *
     hltInclusiveVBFSource *
@@ -108,9 +109,20 @@ offlineHLTSource = cms.Sequence(
     btagMonitorHLT *
     bphMonitorHLT *
     hltObjectsMonitor
-    )
+)
+
+# offline DQM for running in the standard RECO,DQM (in PromptReco, ReReco, relval, etc)
+## ADD here only sequences/modules which rely on transient collections produced by the RECO step
+## and not stored in the AOD format
+offlineHLTSource = cms.Sequence(
+    offlineHLTSourceOnAOD
+    + hcalMonitoringSequence
+    + jetMETHLTOfflineAnalyzer
+)
 
 # offline DQM for the HLTMonitoring stream
+## ADD here only sequences/modules which rely on HLT collections which are stored in the HLTMonitoring stream
+## and are not available in the standard RAW format
 dqmInfoHLTMon = cms.EDAnalyzer("DQMEventInfo",
     subSystemFolder = cms.untracked.string('HLT')
     )

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -34,10 +34,11 @@ struct MEPSet {
 class FastTimerServiceClient : public DQMEDHarvester {
 public:
   explicit FastTimerServiceClient(edm::ParameterSet const &);
-  ~FastTimerServiceClient();
+  ~FastTimerServiceClient() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   static void fillLumiMePSetDescription(edm::ParameterSetDescription & pset);
+  static void fillPUMePSetDescription(edm::ParameterSetDescription & pset);
 
 private:
   std::string m_dqm_path;
@@ -54,9 +55,11 @@ private:
 
   bool doPlotsVsScalLumi_;
   bool doPlotsVsPixelLumi_;
+  bool doPlotsVsPU_;
 
   MEPSet scalLumiMEPSet_;
   MEPSet pixelLumiMEPSet_;
+  MEPSet puMEPSet_;
 
 };
 
@@ -65,8 +68,10 @@ FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const & config)
   m_dqm_path( config.getUntrackedParameter<std::string>( "dqmPath" ) )
   , doPlotsVsScalLumi_ ( config.getParameter<bool>( "doPlotsVsScalLumi" )  )
   , doPlotsVsPixelLumi_( config.getParameter<bool>( "doPlotsVsPixelLumi" ) )
-  , scalLumiMEPSet_ ( doPlotsVsScalLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("scalLumiME")) : MEPSet{}  )
+  , doPlotsVsPU_       ( config.getParameter<bool>( "doPlotsVsPU" )        )
+  , scalLumiMEPSet_ ( doPlotsVsScalLumi_  ? getHistoPSet(config.getParameter<edm::ParameterSet>("scalLumiME") ) : MEPSet{} )
   , pixelLumiMEPSet_( doPlotsVsPixelLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("pixelLumiME")) : MEPSet{} )
+  , puMEPSet_       ( doPlotsVsPU_        ? getHistoPSet(config.getParameter<edm::ParameterSet>("puME")   ) : MEPSet{} )
 {
 }
 
@@ -123,7 +128,7 @@ void
 FastTimerServiceClient::fillProcessSummaryPlots(DQMStore::IBooker & booker, DQMStore::IGetter & getter, std::string const & current_path) {
 
   MonitorElement * me = getter.get(current_path + "/event time_real");
-  if (me == 0)
+  if (me == nullptr)
     // no FastTimerService DQM information
     return;
 
@@ -131,6 +136,8 @@ FastTimerServiceClient::fillProcessSummaryPlots(DQMStore::IBooker & booker, DQMS
     fillPlotsVsLumi( booker,getter, current_path, "VsScalLumi", scalLumiMEPSet_ );
   if ( doPlotsVsPixelLumi_ )
     fillPlotsVsLumi( booker,getter, current_path, "VsPixelLumi", pixelLumiMEPSet_ );
+  if ( doPlotsVsPU_ )
+    fillPlotsVsLumi( booker,getter, current_path, "VsPU", puMEPSet_ );
 
   //  getter.setCurrentFolder(current_path);
 
@@ -222,13 +229,13 @@ FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker & booker, DQMStor
 
     getter.setCurrentFolder(subsubdir);
     std::vector<std::string> allmenames = getter.getMEs();
-    if ( allmenames.size() == 0 ) continue;
+    if ( allmenames.empty() ) continue;
 
     MonitorElement * me_counter      = getter.get( subsubdir + "/module_counter" );
     MonitorElement * me_real_total   = getter.get( subsubdir + "/module_time_real_total" );
     MonitorElement * me_thread_total = getter.get( subsubdir + "/module_time_thread_total" );
 
-    if (me_counter == 0 or me_real_total == 0)
+    if (me_counter == nullptr or me_real_total == nullptr)
       continue;
 
     TH1D * counter      = me_counter   ->getTH1D();
@@ -347,6 +354,8 @@ FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker & booker, DQMStor
       fillPlotsVsLumi( booker,getter, subsubdir, "VsScalLumi", scalLumiMEPSet_ );
     if ( doPlotsVsPixelLumi_ )
       fillPlotsVsLumi( booker,getter, subsubdir, "VsPixelLumi", pixelLumiMEPSet_ );
+    if ( doPlotsVsPU_ )
+      fillPlotsVsLumi( booker,getter, subsubdir, "VsPU", puMEPSet_ );
 
   }
 
@@ -369,7 +378,7 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
       menames.push_back(m);
   }
   // if no MEs available, return
-  if ( menames.size() == 0 )
+  if ( menames.empty() )
     return;
 
   // get info for getting the lumi VS LS histogram
@@ -379,7 +388,7 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
   double      xmin   = pset.xmin;
   double      xmax   = pset.xmax;
 
-  // get lumi VS LS ME
+  // get lumi/PU VS LS ME
   getter.setCurrentFolder(folder);
   MonitorElement* lumiVsLS = getter.get(folder+"/"+name);
   // if no ME available, return
@@ -409,8 +418,8 @@ FastTimerServiceClient::fillPlotsVsLumi(DQMStore::IBooker & booker, DQMStore::IG
     label.erase(label.find("_byls"));
 
     MonitorElement* me = getter.get(current_path + "/" + m);
-    double ymin        = me->getTProfile()->GetMinimum();
-    double ymax        = me->getTProfile()->GetMaximum();
+    float ymin        = 0.;
+    float ymax        = std::numeric_limits<float>::max();
     std::string ytitle = me->getTProfile()->GetYaxis()->GetTitle();
 
     MonitorElement* meVsLumi = getter.get( current_path + "/" + label + "_" + suffix );
@@ -439,9 +448,19 @@ void
 FastTimerServiceClient::fillLumiMePSetDescription(edm::ParameterSetDescription & pset) {
   pset.add<std::string>("folder", "HLT/LumiMonitoring");
   pset.add<std::string>("name"  , "lumiVsLS");
-  pset.add<int>   ("nbins",  6500 );
+  pset.add<int>   ("nbins",   440 );
   pset.add<double>("xmin",      0.);
-  pset.add<double>("xmax",  13000.);
+  pset.add<double>("xmax",  22000.);
+}
+
+
+void 
+FastTimerServiceClient::fillPUMePSetDescription(edm::ParameterSetDescription & pset) {
+  pset.add<std::string>("folder", "HLT/LumiMonitoring");
+  pset.add<std::string>("name"  , "puVsLS");
+  pset.add<int>   ("nbins", 260 );
+  pset.add<double>("xmin",    0.);
+  pset.add<double>("xmax",  130.);
 }
 
 
@@ -464,6 +483,7 @@ FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions & descri
   desc.addUntracked<std::string>( "dqmPath", "HLT/TimerService");
   desc.add<bool>( "doPlotsVsScalLumi",  true  );
   desc.add<bool>( "doPlotsVsPixelLumi", false );
+  desc.add<bool>( "doPlotsVsPU",        true  );
 
   edm::ParameterSetDescription scalLumiMEPSet;
   fillLumiMePSetDescription(scalLumiMEPSet);
@@ -473,6 +493,10 @@ FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions & descri
   fillLumiMePSetDescription(pixelLumiMEPSet);
   desc.add<edm::ParameterSetDescription>("pixelLumiME", pixelLumiMEPSet);
 
+  edm::ParameterSetDescription puMEPSet;
+  fillPUMePSetDescription(puMEPSet);
+  desc.add<edm::ParameterSetDescription>("puME", puMEPSet);
+  
   descriptions.add("fastTimerServiceClient", desc);
 }
 

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessors_cff.py
@@ -7,17 +7,17 @@ def efficiency_string(objtype,plot_type,triggerpath):
     # --- IMPORTANT: Add here a elif if you are introduce a new collection
     #                (see EVTColContainer::getTypeString) 
     if objtype == "Mu" :
-	objtypeLatex="#mu"
+      objtypeLatex="#mu"
     elif objtype == "Photon": 
-	objtypeLatex="#gamma"
+      objtypeLatex="#gamma"
     elif objtype == "Ele": 
-	objtypeLatex="e"
+      objtypeLatex="e"
     elif objtype == "MET" :
-	objtypeLatex="MET"
+      objtypeLatex="MET"
     elif objtype == "PFTau": 
-	objtypeLatex="#tau"
+      objtypeLatex="#tau"
     else:
-	objtypeLatex=objtype
+      objtypeLatex=objtype
 
     numer_description = "# gen %s passed the %s" % (objtypeLatex,triggerpath)
     denom_description = "# gen %s " % (objtypeLatex)
@@ -43,7 +43,7 @@ def efficiency_string(objtype,plot_type,triggerpath):
     all_titles = "%s for trigger %s; %s; %s" % (title, triggerpath,
                                         xAxis, yAxis)
     return "Eff_%s_%s '%s' %s_%s %s" % (input_type,triggerpath,
-		    all_titles,input_type,triggerpath,input_type)
+                all_titles,input_type,triggerpath,input_type)
 
 # Adding the reco objects
 def add_reco_strings(strings):
@@ -68,17 +68,17 @@ efficiency_strings = []
 from HLTriggerOffline.SMP.hltSMPValidator_cfi import hltSMPValidator as _config
 triggers = set([])
 for an in _config.analysis:
-	s = _config.__getattribute__(an)
-	vstr = s.__getattribute__("hltPathsToCheck")
-	map(lambda x: triggers.add(x.replace("_v","")),vstr)
+  s = _config.__getattribute__(an)
+  vstr = s.__getattribute__("hltPathsToCheck")
+  map(lambda x: triggers.add(x.replace("_v","")),vstr)
 triggers = list(triggers)
 #------------------------------------------------------------
 
 # Generating the list with all the efficiencies
 for type in plot_types:
     for obj in obj_types:
-	for trig in triggers:
-	    efficiency_strings.append(efficiency_string(obj,type,trig))
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
 
 
 #add the summary plots
@@ -91,9 +91,9 @@ add_reco_strings(efficiency_strings)
 
 
 
-# hltSMPPostSingleEle = hltSMPPostProcessor.clone()
-# hltSMPPostSingleEle.subDirs = ['HLT/SMP/SingleEle']
-# hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
+hltSMPPostSingleEle = hltSMPPostProcessor.clone()
+hltSMPPostSingleEle.subDirs = ['HLT/SMP/SingleEle']
+hltSMPPostSingleEle.efficiencyProfile = efficiency_strings
 
 # hltSMPPostSingleMu = hltSMPPostProcessor.clone()
 # hltSMPPostSingleMu.subDirs = ['HLT/SMP/SingleMu']
@@ -104,9 +104,9 @@ hltSMPPostSinglePhoton.subDirs = ['HLT/SMP/SinglePhoton']
 hltSMPPostSinglePhoton.efficiencyProfile = efficiency_strings
 
 hltSMPPostProcessors = cms.Sequence(
-#		hltSMPPostSingleEle+
-#		hltSMPPostSingleMu+
-		hltSMPPostSinglePhoton
+    hltSMPPostSingleEle+
+#    hltSMPPostSingleMu+
+    hltSMPPostSinglePhoton
 )
 
 

--- a/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPValidator_cfi.py
@@ -5,7 +5,7 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
 		
     hltProcessName = cms.string("HLT"),
     histDirectory  = cms.string("HLT/SMP"),
-    analysis       = cms.vstring("SinglePhoton"),
+    analysis       = cms.vstring("SinglePhoton","SingleEle"),
     
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
@@ -58,9 +58,9 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
     # --- Photons
     Photon_genCut     = cms.string("abs(pdgId) == 22 && status == 1"),
     Photon_recCut     = cms.string("pt > 20 && abs(eta) < 2.4 && hadronicOverEm < 0.1 && ("+\
-		    "   abs(eta) < 1.479 && sigmaIetaIeta < 0.010  || "+\
-		    "   abs(eta) > 1.479 && sigmaIetaIeta < 0.027 ) && "+\
-		    " ecalRecHitSumEtConeDR03 < (5.0+0.012*et) && hcalTowerSumEtConeDR03 < (5.0+0.0005*et )  && trkSumPtSolidConeDR03 < (5.0 + 0.0002*et)" ),
+        "   abs(eta) < 1.479 && sigmaIetaIeta < 0.010  || "+\
+        "   abs(eta) > 1.479 && sigmaIetaIeta < 0.027 ) && "+\
+        " ecalRecHitSumEtConeDR03 < (5.0+0.012*et) && hcalTowerSumEtConeDR03 < (5.0+0.0005*et )  && trkSumPtSolidConeDR03 < (5.0 + 0.0002*et)" ),
     Photon_cutMinPt   = cms.double(20), # TO BE DEPRECATED
     Photon_cutMaxEta  = cms.double(2.4),# TO BE DEPRECATED
 
@@ -80,26 +80,33 @@ hltSMPValidator = cms.EDAnalyzer("HLTHiggsValidator",
     #    * Var_genCut, Var_recCut (cms.string): where Var=Mu, Ele, Photon, MET, PFTau (see above)
 
     SinglePhoton = cms.PSet( 
-	    hltPathsToCheck = cms.vstring(
-		    "HLT_Photon22_v",
-		    "HLT_Photon30_v",
-		    "HLT_Photon36_v",
-		    "HLT_Photon50_v",
-		    "HLT_Photon75_v",
-		    "HLT_Photon90_v",
-		    "HLT_Photon120_v",
-		    "HLT_Photon165_HE10_v",
-		    "HLT_Photon22_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon30_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon36_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon50_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon75_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon90_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon120_R9Id90_HE10_IsoM_v",
-		    "HLT_Photon165_R9Id90_HE10_IsoM_v",
-		    ),
-	    recPhotonLabel  = cms.string("photons"),
-	    # -- Analysis specific cuts
-	    minCandidates = cms.uint32(1), 
-	    ),
+      hltPathsToCheck = cms.vstring(
+        "HLT_Photon33_v",
+        "HLT_Photon50_v",
+        "HLT_Photon75_v",
+        "HLT_Photon90_v",
+        "HLT_Photon120_v",
+        "HLT_Photon165_HE10_v",
+        "HLT_Photon33_R9Id90_HE10_IsoM_v",
+        "HLT_Photon50_R9Id90_HE10_IsoM_v",
+        "HLT_Photon75_R9Id90_HE10_IsoM_v",
+        "HLT_Photon90_R9Id90_HE10_IsoM_v",
+        "HLT_Photon120_R9Id90_HE10_IsoM_v",
+        "HLT_Photon165_R9Id90_HE10_IsoM_v",
+        ),
+      recPhotonLabel  = cms.string("photons"),
+      # -- Analysis specific cuts
+      minCandidates = cms.uint32(1), 
+      ),
+    SingleEle = cms.PSet( 
+      hltPathsToCheck = cms.vstring(
+        "HLT_Ele35_WPTight_Gsf_v",
+        "HLT_Ele38_WPTight_Gsf_v",
+        "HLT_Ele40_WPTight_Gsf_v",
+        "HLT_Ele35_WPTight_Gsf_L1EGMT_v",
+        ),
+      recElecLabel  = cms.string("gedGsfElectrons"),
+      # -- Analysis specific cuts
+      minCandidates = cms.uint32(1), 
+      ),
 )


### PR DESCRIPTION
My task in JIRA is : (https://its.cern.ch/jira/browse/CMSLITDPG-165)

First of all, I needed to make some changes in the code DQM/L1TMonitor/src/L1TStage2uGT.cc . (Of course, in the path : DQM/L1TMonitor/interface/L1TStage2uGT.h, we simply add the new histograms) These changes are mentioned to add some extra plots according to specific L1 Trigger bits (L1_FirstCollisionInTrain and L1_LastCollisionInTrain). So, after I initialize three plots, I used the last two trigger bits, as I mentioned, to fill them. The first plot which called first_bunch, selecting only the L1_FirstCollisionInTrain, is filled with all the algorithm trigger bits (y-axis) and BX (x-axis), the second plot which called last_bunch, selecting only the L1_LastCollisionInTrain, is filled with all the algorithm trigger bits (y-axis) and BX (x-axis), and the last plot called isolated_bunch is filled selecting simultaneously L1_FirstCollisionInTrain and L1_LastCollisionInTrain, is filled with all the algorithm trigger bits (y-axis) and BX (x-axis).